### PR TITLE
Refactor: 代码质量重构 — 修复缺陷、降低耦合、消除重复、降低复杂度

### DIFF
--- a/src/main/java/caa/Config.java
+++ b/src/main/java/caa/Config.java
@@ -1,6 +1,5 @@
 package caa;
 
-import java.util.LinkedList;
 import java.util.List;
 
 public class Config {
@@ -29,5 +28,5 @@ public class Config {
             "All FullPath"
     };
 
-    public static List<String> globalPayload = new LinkedList<>();
+    public static volatile List<String> globalPayload = List.of();
 }

--- a/src/main/java/caa/component/Config.java
+++ b/src/main/java/caa/component/Config.java
@@ -236,13 +236,7 @@ public class Config extends JPanel {
     }
 
     private void addDataToTable(String data, DefaultTableModel model) {
-        if (!data.isBlank()) {
-            String[] rows = data.split("\\r?\\n");
-            for (String row : rows) {
-                model.addRow(new String[]{row});
-            }
-            UIEnhancer.deduplicateTableData(model);
-        }
+        UIEnhancer.addDataToTable(data, model, false, s -> s);
     }
 
 

--- a/src/main/java/caa/component/Databoard.java
+++ b/src/main/java/caa/component/Databoard.java
@@ -3,6 +3,7 @@ package caa.component;
 import burp.api.montoya.MontoyaApi;
 import caa.Config;
 import caa.component.datatable.Datatable;
+import caa.component.datatable.DatatableContext;
 import caa.component.datatable.Mode;
 import caa.component.generator.Generator;
 import caa.instances.Database;
@@ -11,8 +12,6 @@ import caa.utils.HttpUtils;
 import caa.utils.UIEnhancer;
 
 import javax.swing.*;
-import javax.swing.event.DocumentEvent;
-import javax.swing.event.DocumentListener;
 import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -31,7 +30,7 @@ public class Databoard extends JPanel {
     private final String defaultText = "Please enter the host";
     private final DefaultComboBoxModel comboBoxModel = new DefaultComboBoxModel();
     private final JComboBox hostComboBox = new JComboBox(comboBoxModel);
-    private Map<String, List<String>> hostCache = new HashMap<>();
+    private volatile Map<String, List<String>> hostCache = new HashMap<>();
     private JTextField hostTextField;
     private JComboBox<String> tableComboBox;
     private JComboBox<String> limitComboBox;
@@ -138,22 +137,7 @@ public class Databoard extends JPanel {
             }
         });
 
-        hostTextField.getDocument().addDocumentListener(new DocumentListener() {
-            @Override
-            public void insertUpdate(DocumentEvent e) {
-                filterComboBoxList();
-            }
-
-            @Override
-            public void removeUpdate(DocumentEvent e) {
-                filterComboBoxList();
-            }
-
-            @Override
-            public void changedUpdate(DocumentEvent e) {
-                filterComboBoxList();
-            }
-        });
+        UIEnhancer.addSimpleDocumentListener(hostTextField, this::filterComboBoxList);
     }
 
     private void filterComboBoxList() {
@@ -255,12 +239,14 @@ public class Databoard extends JPanel {
                                         columnNameB.add("Name");
                                         columnNameB.add("Value");
                                         columnNameB.add("Count");
-                                        datatableComponent = new Datatable(api, db, configLoader, generator, columnNameB, selectedObject, null, tableName, Mode.COUNT);
+                                        DatatableContext ctx = new DatatableContext(api, db, configLoader, generator, null);
+                                        datatableComponent = new Datatable(ctx, columnNameB, selectedObject, tableName, Mode.COUNT);
                                     } else {
                                         List<String> columnNameA = new ArrayList<>();
                                         columnNameA.add("Name");
                                         columnNameA.add("Count");
-                                        datatableComponent = new Datatable(api, db, configLoader, generator, columnNameA, selectedObject, null, tableName, Mode.COUNT);
+                                        DatatableContext ctx = new DatatableContext(api, db, configLoader, generator, null);
+                                        datatableComponent = new Datatable(ctx, columnNameA, selectedObject, tableName, Mode.COUNT);
                                     }
                                     // 设置当前host，用于删除操作
                                     datatableComponent.setCurrentHost(selectedHost.equals("*") ? "" : selectedHost);
@@ -360,6 +346,6 @@ public class Databoard extends JPanel {
     }
     
     public void clearHostCache() {
-        hostCache.clear();
+        hostCache = new HashMap<>();
     }
 }

--- a/src/main/java/caa/component/datatable/Datatable.java
+++ b/src/main/java/caa/component/datatable/Datatable.java
@@ -5,13 +5,10 @@ import burp.api.montoya.http.message.requests.HttpRequest;
 import caa.component.generator.Generator;
 import caa.instances.Database;
 import caa.instances.payload.PayloadGenerator;
-import caa.utils.ConfigLoader;
 import caa.utils.UIEnhancer;
 import com.google.common.collect.SetMultimap;
 
 import javax.swing.*;
-import javax.swing.event.DocumentEvent;
-import javax.swing.event.DocumentListener;
 import javax.swing.table.DefaultTableModel;
 import javax.swing.table.TableColumn;
 import javax.swing.table.TableRowSorter;
@@ -31,7 +28,6 @@ public class Datatable extends JPanel {
     private final JTextField secondSearchField;
     private final TableRowSorter<DefaultTableModel> sorter;
     private final MontoyaApi api;
-    private final ConfigLoader configLoader;
     private final Generator generator;
     private final JCheckBox searchMode = new JCheckBox("Reverse search");
     private final JCheckBox regexMode = new JCheckBox("Regex mode");
@@ -44,16 +40,15 @@ public class Datatable extends JPanel {
     private final Mode mode;
     private String currentHost = "";
 
-    public Datatable(MontoyaApi api, Database db, ConfigLoader configLoader, Generator generator, List<String> columnNameList, Object dataObj, HttpRequest httpRequest, String tabName, Mode mode) {
-        this.api = api;
-        this.db = db;
-        this.configLoader = configLoader;
-        this.generator = generator;
+    public Datatable(DatatableContext ctx, List<String> columnNameList, Object dataObj, String tabName, Mode mode) {
+        this.api = ctx.api();
+        this.db = ctx.db();
+        this.generator = ctx.generator();
+        this.httpRequest = ctx.httpRequest();
         this.tabName = tabName;
         this.dataObj = dataObj;
-        this.httpRequest = httpRequest;
         this.columnSize = columnNameList.size();
-        this.payloadGenerator = new PayloadGenerator(api, configLoader);
+        this.payloadGenerator = new PayloadGenerator(ctx.api(), ctx.configLoader());
         this.mode = mode;
 
         String[] columnNames = new String[columnSize + 1];
@@ -103,43 +98,11 @@ public class Datatable extends JPanel {
 
         UIEnhancer.setTextFieldPlaceholder(searchField, "Search");
 
-        searchField.getDocument().addDocumentListener(new DocumentListener() {
-            @Override
-            public void insertUpdate(DocumentEvent e) {
-                performSearch();
-            }
-
-            @Override
-            public void removeUpdate(DocumentEvent e) {
-                performSearch();
-            }
-
-            @Override
-            public void changedUpdate(DocumentEvent e) {
-                performSearch();
-            }
-
-        });
+        UIEnhancer.addSimpleDocumentListener(searchField, this::performSearch);
 
         UIEnhancer.setTextFieldPlaceholder(secondSearchField, "Second search");
 
-        secondSearchField.getDocument().addDocumentListener(new DocumentListener() {
-            @Override
-            public void insertUpdate(DocumentEvent e) {
-                performSearch();
-            }
-
-            @Override
-            public void removeUpdate(DocumentEvent e) {
-                performSearch();
-            }
-
-            @Override
-            public void changedUpdate(DocumentEvent e) {
-                performSearch();
-            }
-
-        });
+        UIEnhancer.addSimpleDocumentListener(secondSearchField, this::performSearch);
 
         // 设置布局
         JScrollPane scrollPane = new JScrollPane(dataTable);

--- a/src/main/java/caa/component/datatable/DatatableContext.java
+++ b/src/main/java/caa/component/datatable/DatatableContext.java
@@ -1,0 +1,9 @@
+package caa.component.datatable;
+
+import burp.api.montoya.MontoyaApi;
+import burp.api.montoya.http.message.requests.HttpRequest;
+import caa.component.generator.Generator;
+import caa.instances.Database;
+import caa.utils.ConfigLoader;
+
+public record DatatableContext(MontoyaApi api, Database db, ConfigLoader configLoader, Generator generator, HttpRequest httpRequest) {}

--- a/src/main/java/caa/component/generator/Tab.java
+++ b/src/main/java/caa/component/generator/Tab.java
@@ -13,8 +13,6 @@ import caa.utils.UIEnhancer;
 
 import javax.swing.*;
 import javax.swing.border.EmptyBorder;
-import javax.swing.event.DocumentEvent;
-import javax.swing.event.DocumentListener;
 import javax.swing.table.DefaultTableModel;
 import java.awt.*;
 import java.awt.event.*;
@@ -94,30 +92,12 @@ public class Tab extends JPanel {
         JPanel urlPanel = new JPanel(new BorderLayout(10, 0));
         JLabel urlLabel = new JLabel("URL:");
         urlField = new JTextField(httpRequest.url());
-        urlField.getDocument().addDocumentListener(new DocumentListener() {
-            @Override
-            public void insertUpdate(DocumentEvent e) {
-                changeAction();
-            }
-
-            @Override
-            public void removeUpdate(DocumentEvent e) {
-                changeAction();
-            }
-
-            @Override
-            public void changedUpdate(DocumentEvent e) {
-                changeAction();
-            }
-
-            private void changeAction() {
-                // 改动就重组
-                try {
-                    HttpService httpService = HttpService.httpService(urlField.getText());
-                    requestEditor.setRequest(HttpRequest.httpRequest(httpService, requestEditor.getRequest().toByteArray()));
-                } catch (Exception ignored) {
-
-                }
+        UIEnhancer.addSimpleDocumentListener(urlField, () -> {
+            // 改动就重组
+            try {
+                HttpService httpService = HttpService.httpService(urlField.getText());
+                requestEditor.setRequest(HttpRequest.httpRequest(httpService, requestEditor.getRequest().toByteArray()));
+            } catch (Exception ignored) {
             }
         });
 
@@ -401,23 +381,6 @@ public class Tab extends JPanel {
     }
 
     private void addDataToTable(String data, DefaultTableModel model) {
-        if (data.isBlank()) {
-            return;
-        }
-
-        String[] rows = data.split("\\r?\\n");
-        for (String row : rows) {
-            String[] cellData;
-
-            if (row.contains("=")) {
-                cellData = new String[]{row.split("=")[0], httpUtils.decodeParameter(row.split("=")[1])};
-            } else {
-                cellData = new String[]{row};
-            }
-
-            model.addRow(cellData);
-        }
-
-        UIEnhancer.deduplicateTableData(model);
+        UIEnhancer.addDataToTable(data, model, true, httpUtils::decodeParameter);
     }
 }

--- a/src/main/java/caa/instances/editor/ResponseEditor.java
+++ b/src/main/java/caa/instances/editor/ResponseEditor.java
@@ -11,6 +11,7 @@ import burp.api.montoya.ui.editor.extension.EditorCreationContext;
 import burp.api.montoya.ui.editor.extension.ExtensionProvidedHttpResponseEditor;
 import burp.api.montoya.ui.editor.extension.HttpResponseEditorProvider;
 import caa.component.datatable.Datatable;
+import caa.component.datatable.DatatableContext;
 import caa.component.datatable.Mode;
 import caa.component.generator.Generator;
 import caa.instances.Collector;
@@ -50,6 +51,7 @@ public class ResponseEditor implements HttpResponseEditorProvider {
         private final Generator generator;
 
         private final HttpUtils httpUtils;
+        private final Collector collector;
         private final JTabbedPane jTabbedPane;
         private final EditorCreationContext creationContext;
         private Datatable dataPanel;
@@ -64,6 +66,7 @@ public class ResponseEditor implements HttpResponseEditorProvider {
             this.generator = generator;
 
             this.httpUtils = new HttpUtils(api, configLoader);
+            this.collector = new Collector(api, db, configLoader);
             this.creationContext = creationContext;
             this.jTabbedPane = new JTabbedPane();
         }
@@ -102,7 +105,6 @@ public class ResponseEditor implements HttpResponseEditorProvider {
                 }
 
                 if (!matches) {
-                    Collector collector = new Collector(api, db, configLoader);
                     dataMap = new LinkedHashMap<>(collector.collect(requestResponse));
 
                     return !dataMap.isEmpty();
@@ -160,7 +162,8 @@ public class ResponseEditor implements HttpResponseEditorProvider {
                 if (i.equals("Value")) {
                     columnNameA.add("Value");
                 }
-                component = new Datatable(api, db, configLoader, generator, columnNameA, dataMap.get(i), httpRequest, i, Mode.STANDARD);
+                DatatableContext ctx = new DatatableContext(api, db, configLoader, generator, httpRequest);
+                component = new Datatable(ctx, columnNameA, dataMap.get(i), i, Mode.STANDARD);
                 jTabbedPane.addTab(i, component);
             }
 

--- a/src/main/java/caa/instances/payload/CaAPayloadGenerator.java
+++ b/src/main/java/caa/instances/payload/CaAPayloadGenerator.java
@@ -5,19 +5,23 @@ import burp.api.montoya.intruder.IntruderInsertionPoint;
 import burp.api.montoya.intruder.PayloadGenerator;
 import caa.Config;
 
+import java.util.List;
+
 public class CaAPayloadGenerator implements PayloadGenerator {
     private int payloadIndex = 0;
 
     @Override
     public GeneratedPayload generatePayloadFor(IntruderInsertionPoint insertionPoint) {
-        if (payloadIndex > Config.globalPayload.size()) {
+        List<String> payload = Config.globalPayload;
+
+        if (payloadIndex >= payload.size()) {
             return GeneratedPayload.end();
         }
 
-        String payload = Config.globalPayload.get(payloadIndex);
+        String payloadValue = payload.get(payloadIndex);
 
         payloadIndex++;
 
-        return GeneratedPayload.payload(payload);
+        return GeneratedPayload.payload(payloadValue);
     }
 }

--- a/src/main/java/caa/utils/UIEnhancer.java
+++ b/src/main/java/caa/utils/UIEnhancer.java
@@ -1,6 +1,8 @@
 package caa.utils;
 
 import javax.swing.*;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
 import javax.swing.table.DefaultTableModel;
 import java.awt.*;
 import java.awt.datatransfer.Clipboard;
@@ -12,6 +14,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.function.BiConsumer;
+import java.util.function.Function;
 
 public class UIEnhancer {
     public static void addButtonListener(JButton pasteButton, JButton removeButton, JButton clearButton, JTable table, DefaultTableModel model, BiConsumer<String, DefaultTableModel> addDataToTable) {
@@ -132,5 +135,43 @@ public class UIEnhancer {
     public static boolean hasUserInput(JTextField field) {
         Object prop = field.getClientProperty("isPlaceholder");
         return prop instanceof Boolean && !((Boolean) prop);
+    }
+
+    public static void addSimpleDocumentListener(JTextField field, Runnable action) {
+        field.getDocument().addDocumentListener(new DocumentListener() {
+            @Override
+            public void insertUpdate(DocumentEvent e) {
+                action.run();
+            }
+
+            @Override
+            public void removeUpdate(DocumentEvent e) {
+                action.run();
+            }
+
+            @Override
+            public void changedUpdate(DocumentEvent e) {
+                action.run();
+            }
+        });
+    }
+
+    public static void addDataToTable(String data, DefaultTableModel model, boolean parseKeyValue, Function<String, String> valueDecoder) {
+        if (data.isBlank()) {
+            return;
+        }
+
+        String[] rows = data.split("\\r?\\n");
+        for (String row : rows) {
+            String[] cellData;
+            if (parseKeyValue && row.contains("=")) {
+                cellData = new String[]{row.split("=")[0], valueDecoder.apply(row.split("=")[1])};
+            } else {
+                cellData = new String[]{row};
+            }
+            model.addRow(cellData);
+        }
+
+        deduplicateTableData(model);
     }
 }


### PR DESCRIPTION
## Summary

对 CaA 项目进行 4 个阶段的代码质量重构，净减少 114 行代码。

### Phase 1: 关键缺陷修复
- 修复 `CaAPayloadGenerator` 边界条件 `>` → `>=`，消除 `IndexOutOfBoundsException`
- 修复 `Config.globalPayload` 线程安全问题：`LinkedList` → `volatile` + 不可变列表（`List.of()` / `List.copyOf()`），消除 Intruder 线程与 UI 线程的竞态条件
- 删除 `Database` 中重复的 `PRAGMA temp_store = MEMORY` 声明

### Phase 2: 降低耦合度
- 消除 `ResponseEditor.Editor` 中每次 `isEnabledFor()` 都 `new Collector()` 的问题，改为构造时创建字段复用
- 修复 `Databoard.hostCache` 并发安全：声明为 `volatile`，`clearHostCache()` 改为原子替换引用
- 新增 `DatatableContext` record，将 `Datatable` 构造参数从 9 个降为 5 个

### Phase 3: 消除代码重复
- 合并 `Collector` 中功能完全相同的 `processJsonData()` 和 `applyCachedData()`
- 提取 `processResponseBodyJson()` 方法，消除 `collect()` 中对 JSON 解析逻辑的重复
- 提取 `UIEnhancer.addSimpleDocumentListener()`，替换 4 处重复的 `DocumentListener` 匿名类
- 提取 `PayloadGenerator.parsePayloadPairs()`，简化 `generateRawParam`/`generateJsonParam`/`generateXmlParam`
- 统一 `Tab` 和 `Config` 中的 `addDataToTable` 到 `UIEnhancer.addDataToTable()`

### Phase 4: 降低复杂度
- 简化 `Database.deleteData()` 从 73 行 4 层嵌套 if-else 到约 30 行线性 SQL 构建

## Test plan
- [x] `./gradlew clean jar` 编译通过
- [ ] 加载 `build/libs/CaA.jar` 到 BurpSuite 确认被动扫描收集功能正常
- [ ] 确认 Databoard 数据浏览、搜索、删除功能正常
- [ ] 确认 Generator Payload 生成及 Intruder 集成功能正常
- [ ] 确认 ResponseEditor 中 CollectInfo Tab 显示正常